### PR TITLE
Output scale median

### DIFF
--- a/cherno/actor/__init__.py
+++ b/cherno/actor/__init__.py
@@ -20,6 +20,7 @@ ChernoCommandType = Union[Command[ChernoActor], FakeCommand]
 from .acquire import *
 from .guide import *
 from .offset import *
+from .scale import *
 from .set import *
 from .show import *
 from .status import *

--- a/cherno/actor/actor.py
+++ b/cherno/actor/actor.py
@@ -80,6 +80,7 @@ class ChernoState:
     acquisition: dict = field(default_factory=dict)
     enabled_cameras: list = field(default_factory=list)
     enabled_axes: list = field(default_factory=list)
+    scale_history: list = field(default_factory=list)
 
     def __post_init__(self):
         self.guide_loop = config["guide_loop"].copy()

--- a/cherno/actor/scale.py
+++ b/cherno/actor/scale.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2022-01-28
+# @Filename: scale.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import time
+
+import click
+import numpy
+
+from . import ChernoCommandType, cherno_parser
+
+
+__all__ = ["get_scale"]
+
+
+@cherno_parser.command(name="get-scale")
+@click.option(
+    "--max-age",
+    type=int,
+    default=1200,
+    help="Maximum age of the scale data points to consider, in seconds.",
+)
+@click.option(
+    "--min-points",
+    type=int,
+    default=10,
+    help="Minimum number of points to use.",
+)
+@click.option(
+    "--sigma",
+    type=float,
+    default=3,
+    help="Sigma-clip rejection.",
+)
+async def get_scale(
+    command: ChernoCommandType,
+    max_age: int = 1200,
+    min_points: int = 10,
+    sigma: float = 3.0,
+):
+    """Outputs the median, sigma-clipped scale from existing mesurements.
+
+    This command is mainly called by jaeger when determining what scale correction
+    to apply to a new configuration.
+
+    """
+
+    data = numpy.array(command.actor.state.scale_history)
+
+    # Require at least
+    if len(data) == 0:
+        command.warning("Not enough points to calculate median scale.")
+        return command.finish(scale_median=-999.0)
+
+    # Make first column the delat wrt now.
+    data[:, 0] = time.time() - data[:, 0]
+
+    valid = data[data[:, 0] < max_age]
+    if len(valid) < min_points:
+        command.warning("Not enough points to calculate median scale.")
+        return command.finish(scale_median=-999.0)
+
+    scales = valid[:, 1]
+
+    median0 = numpy.median(scales)
+    std = numpy.std(scales)
+
+    clipped = scales[numpy.abs(scales - median0) <= sigma * std]
+
+    if len(clipped) < 3:
+        command.warning("Too few data points after sigma clipping.")
+        return command.finish(scale_median=-999.0)
+
+    return command.finish(scale_median=numpy.round(numpy.median(clipped), 7))

--- a/cherno/astrometry.py
+++ b/cherno/astrometry.py
@@ -804,6 +804,12 @@ async def process_and_correct(
         ]
     )
 
+    if delta_scale > 0:
+        # If we measured the scale, add it to the actor state. This is later
+        # used to compute the average scale over a period. We also add the time
+        # because we'll want to reject measurements that are too old.
+        command.actor.state.scale_history.append((time.time(), delta_scale))
+
     actor_state = command.actor.state
     guider_status = actor_state.status
 

--- a/cherno/etc/schema.json
+++ b/cherno/etc/schema.json
@@ -96,7 +96,8 @@
     "pid_rot": {
       "type": "array",
       "items": [{ "title": "rot_kp", "type": "number" }]
-    }
+    },
+    "scale_median": { "type": "number" }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
Scale measurements and timestamps are stored. The command `cherno get-scale` outputs the sigclipped median of the scale values.